### PR TITLE
Implement localized threat monitor

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const title = screen.getByText(/Home Hub Dashboard/i);
+  expect(title).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ProjectTracker } from './components/projectTracker';
 import { MaintenanceSchedule } from './components/maintenanceSchedule';
 import { BillsFinances } from './components/billsFinances';
 import { HomeCalendar } from './components/homeCalendar';
+import { ThreatMonitor } from './components/threatMonitor';
 import { useCurrentView } from './stores/homeStore';
 
 const drawerWidth = 280;
@@ -38,6 +39,8 @@ function App() {
         return <BillsFinances />;
       case 'calendar':
         return <HomeCalendar />;
+      case 'threats':
+        return <ThreatMonitor />;
       default:
         return <DashboardOverview />;
     }

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -17,6 +17,7 @@ import {
   Build,
   Receipt,
   CalendarMonth,
+  Warning,
   Home,
 } from '@mui/icons-material';
 import { useCurrentView, useHomeStore } from '../stores/homeStore';
@@ -50,10 +51,15 @@ const menuItems = [
     label: 'Bills & Finances', 
     icon: <Receipt /> 
   },
-  { 
-    key: 'calendar' as AppState['currentView'], 
-    label: 'Calendar', 
-    icon: <CalendarMonth /> 
+  {
+    key: 'calendar' as AppState['currentView'],
+    label: 'Calendar',
+    icon: <CalendarMonth />
+  },
+  {
+    key: 'threats' as AppState['currentView'],
+    label: 'Threat Monitor',
+    icon: <Warning />
   },
 ];
 

--- a/src/components/threatMonitor.tsx
+++ b/src/components/threatMonitor.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { Box, Card, CardContent, Typography, Button, List, ListItem, ListItemText } from '@mui/material';
+import { useHomeStore, useThreatSummaries } from '../stores/homeStore';
+
+export const ThreatMonitor: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const summaries = useThreatSummaries();
+  const fetchThreatSummary = useHomeStore(state => state.fetchThreatSummary);
+
+  const handleRefresh = async () => {
+    setLoading(true);
+    try {
+      await fetchThreatSummary({ lat: 39.95, lon: -75.16 });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ width: '100%', p: { xs: 2, md: 3 } }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+        <Box>
+          <Typography variant="h4" sx={{ fontWeight: 600, mb: 1 }}>
+            Threat Monitor
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Localized weather, outage and crime alerts
+          </Typography>
+        </Box>
+        <Button variant="contained" onClick={handleRefresh} disabled={loading}>
+          {loading ? 'Loading...' : 'Refresh'}
+        </Button>
+      </Box>
+
+      {summaries.map(summary => (
+        <Card key={summary.id} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6" sx={{ fontWeight: 600 }}>
+              {summary.date.toLocaleString()} - {summary.level}
+            </Typography>
+            <List>
+              {summary.weatherAlerts.map((a, i) => (
+                <ListItem key={`w-${i}`}>
+                  <ListItemText primary={a} secondary="Weather" />
+                </ListItem>
+              ))}
+              {summary.powerOutages.map((a, i) => (
+                <ListItem key={`p-${i}`}>
+                  <ListItemText primary={a} secondary="Power" />
+                </ListItem>
+              ))}
+              {summary.crimeReports.map((a, i) => (
+                <ListItem key={`c-${i}`}>
+                  <ListItemText primary={a} secondary="Crime" />
+                </ListItem>
+              ))}
+            </List>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+};

--- a/src/services/threatService.ts
+++ b/src/services/threatService.ts
@@ -1,0 +1,52 @@
+import { ThreatLevel } from '../types';
+
+export interface ThreatData {
+  weatherAlerts: string[];
+  crimeReports: string[];
+  powerOutages: string[];
+}
+
+export const fetchWeatherAlerts = async (lat: number, lon: number): Promise<string[]> => {
+  const url = `https://api.weather.gov/alerts/active?point=${lat},${lon}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.features || []).map((f: any) => f.properties.headline as string);
+  } catch {
+    return [];
+  }
+};
+
+export const fetchCrimeReports = async (lat: number, lon: number): Promise<string[]> => {
+  // Example using Crimeometer API (requires API key)
+  const apiKey = 'YOUR_CRIME_API_KEY';
+  const now = new Date();
+  const past = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000); // last week
+  const url = `https://api.crimeometer.com/v3/incidents/raw-data?lat=${lat}&lon=${lon}&distance=1mi&datetime_ini=${past.toISOString()}&datetime_end=${now.toISOString()}`;
+  try {
+    const res = await fetch(url, { headers: { 'x-api-key': apiKey } });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.incidents || []).map((i: any) => i.incident_offense as string);
+  } catch {
+    return [];
+  }
+};
+
+export const fetchPowerOutages = async (_lat: number, _lon: number): Promise<string[]> => {
+  // Placeholder for a public outage API
+  return [];
+};
+
+export const summarizeThreatLevel = (data: ThreatData): ThreatLevel => {
+  let score = 0;
+  if (data.weatherAlerts.length) score += 2;
+  if (data.crimeReports.length > 2) score += 1;
+  if (data.powerOutages.length) score += 1;
+
+  if (score >= 3) return 'Severe';
+  if (score === 2) return 'High';
+  if (score === 1) return 'Moderate';
+  return 'Low';
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,18 @@ export interface CalendarEvent {
   attendees?: string[];
 }
 
+// Threat Monitoring Types
+export type ThreatLevel = 'Low' | 'Moderate' | 'High' | 'Severe';
+
+export interface ThreatSummary {
+  id: string;
+  date: Date;
+  weatherAlerts: string[];
+  crimeReports: string[];
+  powerOutages: string[];
+  level: ThreatLevel;
+}
+
 // Dashboard Types
 export interface DashboardData {
   currentTemperature: TemperatureReading;
@@ -144,13 +156,16 @@ export interface AppState {
   
   // Calendar
   calendarEvents: CalendarEvent[];
-  
+
   // Dashboard
   dashboardData: DashboardData;
-  
+
+  // Threat Monitoring
+  threatSummaries: ThreatSummary[];
+
   // UI State
   selectedRoom: RoomType | 'All';
-  currentView: 'dashboard' | 'climate' | 'projects' | 'maintenance' | 'bills' | 'calendar';
+  currentView: 'dashboard' | 'climate' | 'projects' | 'maintenance' | 'bills' | 'calendar' | 'threats';
 }
 
 export interface AppActions {
@@ -188,4 +203,8 @@ export interface AppActions {
   
   // Dashboard actions
   refreshDashboard: () => void;
-} 
+
+  // Threat monitoring actions
+  fetchThreatSummary: (location: { lat: number; lon: number }) => Promise<void>;
+}
+


### PR DESCRIPTION
## Summary
- integrate threat monitoring service with NOAA and sample APIs
- store threat summaries in Zustand store
- add Threat Monitor page and navigation item
- update tests for new dashboard text

## Testing
- `npm test --silent`
- `npm run build:memory --silent` *(fails: Reached heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6848e69c84f883279e1efc69ce236c4d